### PR TITLE
feat: add all project namespaces to the path

### DIFF
--- a/src/Nos/Shared/TwigCodeSniffer/TwigCodeSnifferConfig.php
+++ b/src/Nos/Shared/TwigCodeSniffer/TwigCodeSnifferConfig.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Copyright (c) Andreas Penz
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+declare(strict_types=1);
+
+namespace Nos\Shared\TwigCodeSniffer;
+
+use Spryker\Shared\Kernel\AbstractSharedConfig;
+use Spryker\Shared\Kernel\KernelConstants;
+
+class TwigCodeSnifferConfig extends AbstractSharedConfig
+{
+    /**
+     * @return array<string>
+     */
+    public function getProjectNamespaces(): array
+    {
+        return $this->get(KernelConstants::PROJECT_NAMESPACES);
+    }
+}

--- a/src/Nos/Yves/TwigCodeSniffer/TwigCodeSnifferConfig.php
+++ b/src/Nos/Yves/TwigCodeSniffer/TwigCodeSnifferConfig.php
@@ -12,23 +12,29 @@ namespace Nos\Yves\TwigCodeSniffer;
 
 use Spryker\Yves\Kernel\AbstractBundleConfig;
 
+/**
+ * @method \Nos\Shared\TwigCodeSniffer\TwigCodeSnifferConfig getSharedConfig()
+ */
 class TwigCodeSnifferConfig extends AbstractBundleConfig
 {
+    /**
+     * @return array<string>
+     */
+    public function getPaths(): array
+    {
+        $paths = [];
+        foreach ($this->getSharedConfig()->getProjectNamespaces() as $projectNamespace) {
+            $paths[] = APPLICATION_SOURCE_DIR . '/' . $projectNamespace . '/Yves/*/Theme/*/**';
+        }
+
+        return $paths;
+    }
+
     /**
      * @return string
      */
     public function getCacheFilePath(): string
     {
         return APPLICATION_ROOT_DIR . '/data/tmp/.twig-cs-yves.cache';
-    }
-
-    /**
-     * @return array<string>
-     */
-    public function getPaths(): array
-    {
-        return [
-            APPLICATION_ROOT_DIR . '/src/Pyz/Yves/*/Theme/*/**',
-        ];
     }
 }


### PR DESCRIPTION
to scan all theme dirs automatically the configured project namespaces are used to construct the corresponding paths.

resolve #1